### PR TITLE
fix/redis-url-pattern

### DIFF
--- a/targets/compose/redis.go
+++ b/targets/compose/redis.go
@@ -14,8 +14,8 @@ var (
 		Ports: []string{
 			"6379:6379",
 		},
-		ExternalURLPattern: "%s:6379/0",
-		InternalURLPattern: "%s:6379/0",
+		ExternalURLPattern: "//%s:6379/0",
+		InternalURLPattern: "//%s:6379/0",
 	}
 
 	// RedisTestService represents a docker compose redis service.
@@ -28,7 +28,7 @@ var (
 		Ports: []string{
 			"6380:6379",
 		},
-		ExternalURLPattern: "%s:6380/0",
-		InternalURLPattern: "%s:6379/0",
+		ExternalURLPattern: "//%s:6380/0",
+		InternalURLPattern: "//%s:6379/0",
 	}
 )


### PR DESCRIPTION
Services using mage-generated `.env` files fail to start due to the error:
`redis config error: parse "127.0.0.1:6379/0": first path segment in URL cannot contain colon`

This change ensures the generated Redis URL conforms to the _network-path_ reference format (see https://tools.ietf.org/html/rfc3986#section-4.2) so that host and path components can be parsed correctly.