### PR TITLE
Delete all protos before re-generating

### DIFF
--- a/example/mage.go
+++ b/example/mage.go
@@ -14,8 +14,9 @@ func init() {
 	targets.DockerComposeTestDependencies = []string{"cockroach"}
 	targets.DockerRunImage = targets.DockerRunImageMigrations
 	targets.ProtoServices = []string{"products"}
+	targets.ProtoDefinitionsBranch = "master"
 
-	// Usede to account for the fact that we're importing a dependency from the parent package.
+	// Used to account for the fact that we're importing a dependency from the parent package.
 	targets.InstallVolume = "${PWD}/..:/repo"
 	targets.InstallWorkDir = "/repo/example"
 }

--- a/targets/git.go
+++ b/targets/git.go
@@ -57,7 +57,7 @@ func initSubmodule(name string) error {
 
 func updateSubmodule(name string) error {
 	path := submodulePath(name)
-	return Exec(GitBin, "submodule", "-q", "update", "-f", "--checkout", path)
+	return Exec(GitBin, "submodule", "-q", "update", "--remote", "-f", "--checkout", path)
 }
 
 func deinitSubmodule(name string) error {

--- a/targets/protos.go
+++ b/targets/protos.go
@@ -82,6 +82,10 @@ func genProtosFor(wd, namespace, name, output string) error {
 	if err := os.Chdir(wd); err != nil {
 		return err
 	}
+	protos := path.Join(output, "protos")
+	if err := os.RemoveAll(protos); err != nil {
+		return err
+	}
 	defer os.Chdir(Environment["PWD"])
 	_, err := sh.Exec(
 		Environment, os.Stdout, os.Stderr,


### PR DESCRIPTION
This resulted in an issue where we would retain lingering generated files from older revisions of the RPC submodule. Now the generation will always happen from a clean slate.