### PR TITLE
Feature/rabbitmq

### DIFF
--- a/example/mage.go
+++ b/example/mage.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	targets.ProjectName = "example"
 	targets.ProjectType = "service"
-	targets.DockerComposeDevDependencies = []string{"redis", "cockroach", "minio"}
+	targets.DockerComposeDevDependencies = []string{"redis", "cockroach", "minio", "rabbit"}
 	targets.DockerComposeTestDependencies = []string{"cockroach"}
 	targets.DockerRunImage = targets.DockerRunImageMigrations
 	targets.ProtoServices = []string{"products"}

--- a/targets/compose/compose.go
+++ b/targets/compose/compose.go
@@ -91,6 +91,7 @@ var (
 		"mongo":       MongoService,
 		"mongodb":     MongoService,
 		"minio":       MinioService,
+		"rabbitmq":    RabbitMQService,
 	}
 
 	// TestServices represents all available docker compose services for the testing environment.
@@ -119,5 +120,6 @@ var (
 		"mongo":       "MONGO_URL",
 		"mongodb":     "MONGO_URL",
 		"minio":       "MINIO_URL",
+		"rabbitmq":    "RABBITMQ_URL",
 	}
 )

--- a/targets/compose/compose.go
+++ b/targets/compose/compose.go
@@ -81,45 +81,49 @@ func (sm ServiceManifest) InternalEnvFor(host string, service string) (key strin
 var (
 	// Services represents all available docker compose services for the development environment.
 	Services = ServiceManifest{
+		"cockroach":   CockroachService,
+		"cockroachdb": CockroachService,
+		"minio":       MinioService,
+		"mongo":       MongoService,
+		"mongodb":     MongoService,
+		"mysql":       MySQLService,
 		"pg":          PostgresService,
 		"postgres":    PostgresService,
 		"postgresql":  PostgresService,
-		"mysql":       MySQLService,
-		"cockroach":   CockroachService,
-		"cockroachdb": CockroachService,
-		"redis":       RedisService,
-		"mongo":       MongoService,
-		"mongodb":     MongoService,
-		"minio":       MinioService,
+		"rabbit":      RabbitMQService,
 		"rabbitmq":    RabbitMQService,
+		"redis":       RedisService,
 	}
 
 	// TestServices represents all available docker compose services for the testing environment.
 	TestServices = ServiceManifest{
+		"cockroach":   CockroachTestService,
+		"cockroachdb": CockroachTestService,
+		"minio":       MinioTestService,
+		"mongo":       MongoTestService,
+		"mongodb":     MongoTestService,
+		"mysql":       MySQLTestService,
 		"pg":          PostgresTestService,
 		"postgres":    PostgresTestService,
 		"postgresql":  PostgresTestService,
-		"mysql":       MySQLTestService,
-		"cockroach":   CockroachTestService,
-		"cockroachdb": CockroachTestService,
+		"rabbit":      RabbitMQTestService,
+		"rabbitmq":    RabbitMQTestService,
 		"redis":       RedisTestService,
-		"mongo":       MongoTestService,
-		"mongodb":     MongoTestService,
-		"minio":       MinioTestService,
 	}
 
 	// EnvVarNames represents all available env var names for the given service.
 	EnvVarNames = map[string]string{
+		"cockroach":   "COCKROACH_URL",
+		"cockroachdb": "COCKROACH_URL",
+		"minio":       "MINIO_URL",
+		"mongo":       "MONGO_URL",
+		"mongodb":     "MONGO_URL",
+		"mysql":       "MYSQL_URL",
 		"pg":          "POSTGRES_URL",
 		"postgres":    "POSTGRES_URL",
 		"postgresql":  "POSTGRES_URL",
-		"mysql":       "MYSQL_URL",
-		"cockroach":   "COCKROACH_URL",
-		"cockroachdb": "COCKROACH_URL",
-		"redis":       "REDIS_URL",
-		"mongo":       "MONGO_URL",
-		"mongodb":     "MONGO_URL",
-		"minio":       "MINIO_URL",
+		"rabbit":      "RABBITMQ_URL",
 		"rabbitmq":    "RABBITMQ_URL",
+		"redis":       "REDIS_URL",
 	}
 )

--- a/targets/compose/rabbit.go
+++ b/targets/compose/rabbit.go
@@ -1,0 +1,18 @@
+package compose
+
+var (
+	// RabbitMQService represents a docker compose RabbitMQ service.
+	RabbitMQService = Service{
+		Image: "rabbitmq:3-management",
+		Logging: map[string]string{
+			"driver": "none",
+		},
+		Restart: "always",
+		Ports: []string{
+			"15672:15672",
+			"5672:5672",
+		},
+		ExternalURLPattern: "amqp://guest@%s:5672",
+		InternalURLPattern: "amqp://guest@%s:5672",
+	}
+)

--- a/targets/compose/rabbit.go
+++ b/targets/compose/rabbit.go
@@ -3,7 +3,7 @@ package compose
 var (
 	// RabbitMQService represents a docker compose RabbitMQ service.
 	RabbitMQService = Service{
-		Image: "rabbitmq:3-management",
+		Image: "rabbitmq:3.5.7-management",
 		Logging: map[string]string{
 			"driver": "none",
 		},
@@ -14,5 +14,20 @@ var (
 		},
 		ExternalURLPattern: "amqp://guest@%s:5672",
 		InternalURLPattern: "amqp://guest@%s:5672",
+	}
+
+	// RabbitMQTestService represents a test-time docker compose RabbitMQ service.
+	RabbitMQTestService = Service{
+		Image: "rabbitmq:3.5.7-management",
+		Logging: map[string]string{
+			"driver": "none",
+		},
+		Restart: "always",
+		Ports: []string{
+			"15673:15672",
+			"5673:5672",
+		},
+		ExternalURLPattern: "amqp://guest@%s:5673",
+		InternalURLPattern: "amqp://guest@%s:5673",
 	}
 )

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -227,6 +227,14 @@ func (Mod) Cockroach() error {
 	return goget(libs...)
 }
 
+// RabbitMQ installs or upgrades the rabbit packages
+func (Mod) RabbitMQ() error {
+	libs := []string{
+		"github.com/streadway/amqp",
+	}
+	return goget(libs...)
+}
+
 // Redis installs or upgrades the redis packages
 func (Mod) Redis() error {
 	libs := []string{

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -227,8 +227,8 @@ func (Mod) Cockroach() error {
 	return goget(libs...)
 }
 
-// RabbitMQ installs or upgrades the rabbit packages
-func (Mod) RabbitMQ() error {
+// Rabbit installs or upgrades the rabbit packages
+func (Mod) Rabbit() error {
 	libs := []string{
 		"github.com/streadway/amqp",
 	}


### PR DESCRIPTION
Added RabbitMQ as a mage target.

The payment-gateway needs to be able to capture payments on-dispatch, meaning we have to listen for dispatch notifications from the FSMS, which are sent to a RabbitMQ exchange that we can bind to.

This branch adds dev and test targets for RabbitMQ but does not add any infra changes to the charts, because other than a local dev/test environment, we'll never need to spin up infra for RabbitMQ as it's all hosted externally.