### PR TITLE
feat: add support for firebase database

### DIFF
--- a/targets/compose/compose.go
+++ b/targets/compose/compose.go
@@ -93,6 +93,7 @@ var (
 		"rabbit":      RabbitMQService,
 		"rabbitmq":    RabbitMQService,
 		"redis":       RedisService,
+		"firebase":    FirebaseService,
 	}
 
 	// TestServices represents all available docker compose services for the testing environment.
@@ -109,6 +110,7 @@ var (
 		"rabbit":      RabbitMQTestService,
 		"rabbitmq":    RabbitMQTestService,
 		"redis":       RedisTestService,
+		"firebase":    FirebaseTestService,
 	}
 
 	// EnvVarNames represents all available env var names for the given service.
@@ -125,5 +127,6 @@ var (
 		"rabbit":      "RABBITMQ_URL",
 		"rabbitmq":    "RABBITMQ_URL",
 		"redis":       "REDIS_URL",
+		"firebase":    "FIREBASE_URL",
 	}
 )

--- a/targets/compose/firebase.go
+++ b/targets/compose/firebase.go
@@ -1,0 +1,33 @@
+package compose
+
+var (
+	// FirebaseService represents a docker compose firebase service.
+	FirebaseService = Service{
+		Image:   "wceolin/firebase-emulator",
+		Restart: "always",
+		Logging: map[string]string{
+			"driver": "none",
+		},
+		Ports: []string{
+			"9898:9000",
+		},
+		ExternalURLPattern: "//%s:9898/0",
+		InternalURLPattern: "//%s:9898/0",
+		Command:            "firebase emulators:start --only database",
+	}
+
+	// FirebaseTestService represents a docker compose firebase service.
+	FirebaseTestService = Service{
+		Image:   "wceolin/firebase-emulator",
+		Restart: "always",
+		Logging: map[string]string{
+			"driver": "none",
+		},
+		Ports: []string{
+			"9899:9000",
+		},
+		ExternalURLPattern: "//%s:9899/0",
+		InternalURLPattern: "//%s:9899/0",
+		Command:            "firebase emulators:start --only database",
+	}
+)


### PR DESCRIPTION
Add in a firebase emulator client to run the realtime database.

Known issue:
- persistent data currently doesnt work.
 